### PR TITLE
Fix Add-Type 's Error Id : TYPE_ALREADY_EXISTS

### DIFF
--- a/SpeculationControl.psm1
+++ b/SpeculationControl.psm1
@@ -18,14 +18,14 @@ function Get-SpeculationControlSettings {
   )
   
   process {
-
-    $NtQSIDefinition = @'
-    [DllImport("ntdll.dll")]
-    public static extern int NtQuerySystemInformation(uint systemInformationClass, IntPtr systemInformation, uint systemInformationLength, IntPtr returnLength);
-'@
-    
-    $ntdll = Add-Type -MemberDefinition $NtQSIDefinition -Name 'ntdll' -Namespace 'Win32' -PassThru
-
+    if ($(try { [bool]([Win32.ntdll] -as [Type]) }catch { $false })) {
+        Write-Verbose "Type [Win32.ntdll] already exist, using it now ..."
+        $ntdll = [Win32.ntdll]
+    } else {
+        Write-Verbose "Add-Type [Win32.ntdll] ..."
+        $NtQSIDefinition = '[DllImport("ntdll.dll")] public static extern int NtQuerySystemInformation(uint systemInformationClass, IntPtr systemInformation, uint systemInformationLength, IntPtr returnLength);'
+        $ntdll = Add-Type -MemberDefinition $NtQSIDefinition -Name 'ntdll' -Namespace 'Win32' -PassThru
+    }
 
     [System.IntPtr]$systemInformationPtr = [System.Runtime.InteropServices.Marshal]::AllocHGlobal(4)
     [System.IntPtr]$returnLengthPtr = [System.Runtime.InteropServices.Marshal]::AllocHGlobal(4)


### PR DESCRIPTION
## FullyQualifiedErrorId : TYPE_ALREADY_EXISTS
Error occurs When you run the function for the second time. i.e:

```PowerShell
Add-Type -MemberDefinition $NtQSIDefinition -Name 'ntdll' -Namespace 'Win32' -PassThru
```
```text
Add-Type : Cannot add type. The type name 'Win32.ntdll' already exists.
At line:1 char:1
+ Add-Type -MemberDefinition $NtQSIDefinition -Name 'ntdll' -Namespace  ...
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (Win32.ntdll:String) [Add-Type], Exception
    + FullyQualifiedErrorId : TYPE_ALREADY_EXISTS,Microsoft.PowerShell.Commands.AddTypeCommand
```

Its seems powershell can't load the type twice!

```PowerShell
$Error[0] | fl * -Force
```
```text
PSMessageDetails      :
Exception             : System.Exception: Cannot add type. The type name 'Win32.ntdll' already exists.
                           at System.Management.Automation.MshCommandRuntime.ThrowTerminatingError(ErrorRecord errorRecord)
TargetObject          : Win32.ntdll
CategoryInfo          : InvalidOperation: (Win32.ntdll:String) [Add-Type], Exception
FullyQualifiedErrorId : TYPE_ALREADY_EXISTS,Microsoft.PowerShell.Commands.AddTypeCommand
ErrorDetails          :
InvocationInfo        : System.Management.Automation.InvocationInfo
ScriptStackTrace      : at <ScriptBlock>, <No file>: line 1
PipelineIterationInfo : {}
```
